### PR TITLE
feat: validate the textarea is not empty

### DIFF
--- a/igniteFeed/src/components/Post.jsx
+++ b/igniteFeed/src/components/Post.jsx
@@ -10,7 +10,7 @@ export function Post({author, publishdAt, content}){
         'Um post muito bacana!'
     ])
 
-const [newCommentText, setNewCommenttext] = useState("")
+const [newCommentText, setNewCommenttext] = useState('')
 
 const publishedDateFormatted = format(publishdAt, "d 'de' LLLL 'às' HH:mm'h'", {
     locale: ptBR,
@@ -28,7 +28,12 @@ function handleCreateNewComment(){
 }
 
 function handleNewCommentChange(){
-   setNewCommenttext(event.target.value)
+    event.target.setCustomValidity('')
+    setNewCommenttext(event.target.value)
+}
+
+function handleNewCommentInvalid(){
+    event.target.setCustomValidity('Este campo é obrigatório')
 }
 
 function deleteComment(commentToDelete){
@@ -68,10 +73,12 @@ function deleteComment(commentToDelete){
                     placeholder='Deixe seu comentário'
                     value={newCommentText}
                     onChange={handleNewCommentChange}
+                    onInvalid={handleNewCommentInvalid}
+                    required={true}
                     />
                 <footer>
 
-                    <button type='submit'>Publicar</button>
+                    <button type='submit' disabled={newCommentText.length == 0}>Publicar</button>
                 </footer>
             </form>
             <div className={styles.commentList}>

--- a/igniteFeed/src/components/Post.module.css
+++ b/igniteFeed/src/components/Post.module.css
@@ -82,7 +82,7 @@
 
     
 }
-.commentForm button[type=submit]:hover{
+.commentForm button[type=submit]:not(:disabled):hover{
     background: var(--green-300);
 }
 .commentForm footer{
@@ -95,4 +95,8 @@
 }
 .commentList{
 margin-top: 2rem;  
+}
+.commentForm button[type=submit]:disabled{
+    opacity: 0.7;
+    cursor: not-allowed;
 }


### PR DESCRIPTION
# **Definition of Ready (DoR)**

## **Feature**

feat: validate the textarea is not empty

---

## **User Story**

**As a:** User  
**I want:** Be prevented from submitting empty textareas  
**So that:** I don't accidentally submit incomplete or invalid data

---

### **Need**

Ensure the textarea has content before allowing form submission

---

### **Solution**

Add a frontend validation that checks if the textarea is not empty.  
Disable the submit button or show an error message if the textarea is empty.

---

### **Risks, Points of Attention, and Error Handling**

- **Risk**: Validation bypassed via developer tools  
  **Mitigation**: Add server-side validation as a backup

- **Risk**: Poor UX if validation is not clearly indicated  
  **Mitigation**: Show a visible and clear error message near the textarea

- **Risk**: Breaking existing form submissions  
  **Mitigation**: Test all forms that use textareas

- **Risk**:   
  **Mitigation**: 

**Points of Attention**:  
Ensure both client-side and server-side validation work properly and the user gets clear feedback

---

### **Acceptance Criteria**

- The form cannot be submitted with an empty textarea  
- An error message is displayed when attempting to submit an empty field  
- No regressions in existing forms